### PR TITLE
Move composer config plugin output dir to runtime/build/config, same …

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,7 @@
             "dev-master": "1.0.x-dev"
         },
         "config-plugin": {
+            "config-plugin-output-dir": "runtime/build/config",
             "common": "config/common.php",
             "params": [
                 "config/params.php",


### PR DESCRIPTION
…as in yii-demo

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 