### PR TITLE
Fix composer-config-plugin incorrect configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,8 +57,8 @@
         "branch-alias": {
             "dev-master": "1.0.x-dev"
         },
+        "config-plugin-output-dir": "runtime/build/config",
         "config-plugin": {
-            "config-plugin-output-dir": "runtime/build/config",
             "common": "config/common.php",
             "params": [
                 "config/params.php",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any

`config-plugin-output-dir` key is used in incorrect place due to which configuration generation fails.