### PR TITLE
Use HTTP Software implementation of PSR HTTP interfaces

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "yiisoft/yii-event": "@dev",
         "yiisoft/yii-web": "@dev",
         "yiisoft/composer-config-plugin": "^1.0@dev",
-        "httpsoft/http-basis": "^1.0.0"
+        "httpsoft/http-message": "^1.0.0"
     },
     "require-dev": {
         "roave/security-advisories": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
     },
     "require": {
         "php": "^7.4|^8.0",
-        "nyholm/psr7": "^1.3.0",
         "foxy/foxy": "^1.0.8",
         "yiisoft/aliases": "^1.0",
         "yiisoft/assets": "@dev",
@@ -37,7 +36,8 @@
         "yiisoft/yii-debug": "@dev",
         "yiisoft/yii-event": "@dev",
         "yiisoft/yii-web": "@dev",
-        "yiisoft/composer-config-plugin": "^1.0@dev"
+        "yiisoft/composer-config-plugin": "^1.0@dev",
+        "httpsoft/http-basis": "^1.0.0"
     },
     "require-dev": {
         "roave/security-advisories": "dev-master",

--- a/src/Provider/Psr17Provider.php
+++ b/src/Provider/Psr17Provider.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace App\Provider;
 
-use HttpSoft\Request\RequestFactory;
-use HttpSoft\Request\ServerRequestFactory;
-use HttpSoft\Response\ResponseFactory;
-use HttpSoft\Stream\StreamFactory;
-use HttpSoft\UploadedFile\UploadedFileFactory;
-use HttpSoft\Uri\UriFactory;
+use HttpSoft\Message\RequestFactory;
+use HttpSoft\Message\ServerRequestFactory;
+use HttpSoft\Message\ResponseFactory;
+use HttpSoft\Message\StreamFactory;
+use HttpSoft\Message\UploadedFileFactory;
+use HttpSoft\Message\UriFactory;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ServerRequestFactoryInterface;

--- a/src/Provider/Psr17Provider.php
+++ b/src/Provider/Psr17Provider.php
@@ -4,7 +4,12 @@ declare(strict_types=1);
 
 namespace App\Provider;
 
-use Nyholm\Psr7\Factory\Psr17Factory;
+use HttpSoft\Request\RequestFactory;
+use HttpSoft\Request\ServerRequestFactory;
+use HttpSoft\Response\ResponseFactory;
+use HttpSoft\Stream\StreamFactory;
+use HttpSoft\UploadedFile\UploadedFileFactory;
+use HttpSoft\Uri\UriFactory;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ServerRequestFactoryInterface;
@@ -25,12 +30,12 @@ final class Psr17Provider extends ServiceProvider
      */
     public function register(Container $container): void
     {
-        $container->set(RequestFactoryInterface::class, Psr17Factory::class);
-        $container->set(ServerRequestFactoryInterface::class, Psr17Factory::class);
-        $container->set(ResponseFactoryInterface::class, Psr17Factory::class);
-        $container->set(StreamFactoryInterface::class, Psr17Factory::class);
-        $container->set(UriFactoryInterface::class, Psr17Factory::class);
-        $container->set(UploadedFileFactoryInterface::class, Psr17Factory::class);
+        $container->set(RequestFactoryInterface::class, RequestFactory::class);
+        $container->set(ServerRequestFactoryInterface::class, ServerRequestFactory::class);
+        $container->set(ResponseFactoryInterface::class, ResponseFactory::class);
+        $container->set(StreamFactoryInterface::class, StreamFactory::class);
+        $container->set(UriFactoryInterface::class, UriFactory::class);
+        $container->set(UploadedFileFactoryInterface::class, UploadedFileFactory::class);
         $container->set(DataResponseFormatterInterface::class, HtmlDataResponseFormatter::class);
         $container->set(DataResponseFactoryInterface::class, DataResponseFactory::class);
     }


### PR DESCRIPTION
The implementation [is faster than Nyholm one](https://github.com/devanych/psr-http-benchmark). We can try adopting it by default.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -
