### PR TITLE
Remove dubbing aliases config

### DIFF
--- a/config/common.php
+++ b/config/common.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 use App\Contact\ContactMailer;
 use App\Service\Mailer;
 use Psr\Container\ContainerInterface;
-use Yiisoft\Aliases\Aliases;
 
 /* @var array $params */
 
@@ -13,11 +12,6 @@ return [
     ContainerInterface::class => static function (ContainerInterface $container) {
         return $container;
     },
-
-    Aliases::class => [
-        '__class' => Aliases::class,
-        '__construct()' => [$params['aliases']],
-    ],
 
     ContactMailer::class => static function (ContainerInterface $container) use ($params) {
         return (new ContactMailer(

--- a/config/common.php
+++ b/config/common.php
@@ -9,10 +9,6 @@ use Psr\Container\ContainerInterface;
 /* @var array $params */
 
 return [
-    ContainerInterface::class => static function (ContainerInterface $container) {
-        return $container;
-    },
-
     ContactMailer::class => static function (ContainerInterface $container) use ($params) {
         return (new ContactMailer(
             $container->get(Mailer::class),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 

The configuration for the Aliases class in the application duplicates the configuration in the Yii-Web package.

The ContainerInterface creation function is not used and misleads new users with its presence.