### PR TITLE
Remove `/tests/_output` from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,4 @@ phpunit.phar
 .env
 
 #codeception
-/tests/_output
 c3.php


### PR DESCRIPTION
Continue  #57 #58

Wouldn't that hurt those who already have an `tests/_output` folder?