### PR TITLE
Change test server port

### DIFF
--- a/tests/Acceptance.suite.yml
+++ b/tests/Acceptance.suite.yml
@@ -2,10 +2,10 @@ actor: AcceptanceTester
 extensions:
   enabled:
     - Codeception\Extension\RunProcess:
-        0: php -d variables_order=EGPCS -S 127.0.0.1:8080 -t public
+        0: php -d variables_order=EGPCS -S 127.0.0.1:8881 -t public
         sleep: 1
 modules:
   enabled:
     - PhpBrowser:
-        url: http://127.0.0.1:8080
+        url: http://127.0.0.1:8881
   step_decorators: ~


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️

I've changed it because it's impossible to have at the time both a run dev server and a run test server.
Also it's impossible to run tests from `yii-debug-api`. 