### PR TITLE
make `composer run serve` work on windows

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "scripts": {
         "serve": [
             "Composer\\Config::disableProcessTimeout",
-            "./yii serve"
+            "@php ./yii serve"
         ],
         "test": "codecept run",
         "test-watch": "phpunit-watcher watch",


### PR DESCRIPTION
serve add `@php` because windows dont understand shebang on `./yii`

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️/❌
| New feature?  | ✔️/❌
| Breaks BC?    | ✔️/❌
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
