### PR TITLE
Fix composer cache

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -19,7 +19,7 @@ $finder = (new Finder())
     ]);
 
 return (new Config())
-    ->setCacheFile(__DIR__ . '/runtime/.php-cs-fixer.cache')
+    ->setCacheFile(__DIR__ . '/runtime/cache/.php-cs-fixer.cache')
     ->setParallelConfig(ParallelConfigFactory::detect())
     ->setRules([
         '@PER-CS2.0' => true,

--- a/docker/compose.dev.yml
+++ b/docker/compose.dev.yml
@@ -12,13 +12,13 @@ services:
       APP_ENV: "${APP_ENV:-dev}"
       APP_DEBUG: ${APP_DEBUG:-true}
       SERVER_NAME: ":80"
+      COMPOSER_CACHE_DIR: /app/runtime/cache/composer
     restart: unless-stopped
     ports:
       - "${DEV_PORT:-80}:80"
     volumes:
       - ../:/app
       - ../runtime:/app/runtime
-      - ${COMPOSER_CACHE_DIR:-~/.cache/composer}:/var/www/.composer
       - caddy_data:/data
       - caddy_config:/config
     tty: true

--- a/docker/compose.test.yml
+++ b/docker/compose.test.yml
@@ -12,10 +12,10 @@ services:
       APP_ENV: "test"
       APP_DEBUG: "false"
       SERVER_NAME: ":80"
+      COMPOSER_CACHE_DIR: /app/runtime/cache/composer
     volumes:
       - ../:/app
       - ../runtime:/app/runtime
-      - ${COMPOSER_CACHE_DIR:-~/.cache/composer}:/var/www/.composer
       - caddy_data:/data
       - caddy_config:/config
     tty: true

--- a/psalm.xml
+++ b/psalm.xml
@@ -5,7 +5,7 @@
     findUnusedCode="false"
     ensureOverrideAttribute="false"
     strictBinaryOperands="false"
-    cacheDirectory="/app/runtime/psalm-cache"
+    cacheDirectory="/app/runtime/cache/psalm"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌

I have trouble with `~/.cache/composer` usage as composer cache directory.

- Docker create directory `~/.cache/composer` as root.
- PHP in docker runs as current user and composer doesn't have enough rights to write to this directory.
