### PR TITLE
Update layout.php

### DIFF
--- a/src/Layout/Main/layout.php
+++ b/src/Layout/Main/layout.php
@@ -30,7 +30,6 @@ $this->beginPage()
 <html lang="<?= Html::encode($applicationParams->locale) ?>">
 <head>
     <meta charset="<?= Html::encode($applicationParams->charset) ?>">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" href="<?= $aliases->get('@baseUrl/favicon.svg') ?>" type="image/svg+xml">
     <title><?= Html::encode($this->getTitle()) ?></title>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌

In 2025, Internet Explorer 7-11 de facto died. Therefore, I believe that we no longer need this meta tag to support older versions of IE. and Microsoft's modern Edge browser doesn't use it.
