### PR TITLE
The incompatible version of symfony/console has been fixed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "psr/http-message": "^2.0",
         "psr/http-server-handler": "^1.0.2",
         "psr/log": "^3.0.2",
-        "symfony/console": "^7.3",
+        "symfony/console": "<=7.3",
         "yiisoft/aliases": "^3.1.1",
         "yiisoft/assets": "^5.1.2",
         "yiisoft/config": "^1.6.2",


### PR DESCRIPTION
The symfony/console version 7.4 is incompatible because it requires symfony/string: ^7.2|^8.0. The 8.0 version requires PHP: >=8.4. However, the app template php: 8.2 - 8.5.
