### PR TITLE
Harden GitHub workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
       open-pull-requests-limit: 0
 
     # Maintain dependencies for Composer
+      ignore:
+        - dependency-name: "yiisoft/*"
     - package-ecosystem: "composer"
       directory: "/"
       schedule:
@@ -20,3 +22,5 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+      ignore:
+        - dependency-name: "yiisoft/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,8 @@
 version: 2
 updates:
-    # Maintain dependencies for GitHub Actions.
-    - package-ecosystem: "github-actions"
-      directory: "/"
-      schedule:
-          interval: "daily"
-      # Too noisy. See https://github.community/t/increase-if-necessary-for-github-actions-in-dependabot/179581
-      open-pull-requests-limit: 0
-
-    # Maintain dependencies for Composer
-    - package-ecosystem: "composer"
-      directory: "/"
-      schedule:
-          interval: "daily"
-      versioning-strategy: increase-if-necessary
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
       open-pull-requests-limit: 0
 
     # Maintain dependencies for Composer
+      ignore:
+        - dependency-name: "yiisoft/*"
     - package-ecosystem: "composer"
       directory: "/"
       schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,19 @@
 version: 2
 updates:
+    # Maintain dependencies for GitHub Actions.
+    - package-ecosystem: "github-actions"
+      directory: "/"
+      schedule:
+          interval: "daily"
+      # Too noisy. See https://github.community/t/increase-if-necessary-for-github-actions-in-dependabot/179581
+      open-pull-requests-limit: 0
+
+    # Maintain dependencies for Composer
+    - package-ecosystem: "composer"
+      directory: "/"
+      schedule:
+          interval: "daily"
+      versioning-strategy: increase-if-necessary
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,5 @@ updates:
     schedule:
         interval: "daily"
     versioning-strategy: increase-if-necessary
+    cooldown:
+      default-days: 7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,8 @@ on:
 
 name: build
 
+permissions:
+  contents: read
 jobs:
   codeception:
     name: PHP ${{ matrix.php }}-${{ matrix.os }}
@@ -45,10 +47,12 @@ jobs:
 
     steps:
       - name: Checkout.
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Install PHP with extensions.
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
         with:
           coverage: false
           extensions: fileinfo, intl
@@ -56,7 +60,7 @@ jobs:
           php-version: ${{ matrix.php }}
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v3
+        uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f
 
       - name: Run codeception build.
         run: vendor/bin/codecept build
@@ -72,7 +76,7 @@ jobs:
 
       - name: Upload coverage to Codecov.
         if: matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: runtime/tests/_output/coverage.xml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
           persist-credentials: false
 
       - name: Install PHP with extensions.
-        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45 # v2 zizmor: ignore[stale-action-refs]
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           coverage: false
           extensions: fileinfo, intl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,10 @@ on:
 
 name: build
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 jobs:
@@ -47,12 +51,12 @@ jobs:
 
     steps:
       - name: Checkout.
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
       - name: Install PHP with extensions.
-        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45 # v2 zizmor: ignore[stale-action-refs]
         with:
           coverage: false
           extensions: fileinfo, intl
@@ -60,7 +64,7 @@ jobs:
           php-version: ${{ matrix.php }}
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f
+        uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f # 3.2.1
 
       - name: Run codeception build.
         run: vendor/bin/codecept build
@@ -76,7 +80,7 @@ jobs:
 
       - name: Upload coverage to Codecov.
         if: matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: runtime/tests/_output/coverage.xml

--- a/.github/workflows/composer-dependency-analyzer.yml
+++ b/.github/workflows/composer-dependency-analyzer.yml
@@ -22,6 +22,10 @@ on:
 
 name: Composer dependency analyzer
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 jobs:
@@ -42,19 +46,19 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
       - name: Install PHP with extensions
-        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45 # v2 zizmor: ignore[stale-action-refs]
         with:
           coverage: none
           php-version: ${{ matrix.php }}
           tools: composer:v2, cs2pr
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f
+        uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f # 3.2.1
 
       - name: Run composer dependency analyzer
         run: vendor/bin/composer-dependency-analyser --config=composer-dependency-analyser.php

--- a/.github/workflows/composer-dependency-analyzer.yml
+++ b/.github/workflows/composer-dependency-analyzer.yml
@@ -51,7 +51,7 @@ jobs:
           persist-credentials: false
 
       - name: Install PHP with extensions
-        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45 # v2 zizmor: ignore[stale-action-refs]
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           coverage: none
           php-version: ${{ matrix.php }}

--- a/.github/workflows/composer-dependency-analyzer.yml
+++ b/.github/workflows/composer-dependency-analyzer.yml
@@ -22,6 +22,8 @@ on:
 
 name: Composer dependency analyzer
 
+permissions:
+  contents: read
 jobs:
   analyzer:
     name: PHP ${{ matrix.php }}-${{ matrix.os }}
@@ -40,17 +42,19 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Install PHP with extensions
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
         with:
           coverage: none
           php-version: ${{ matrix.php }}
           tools: composer:v2, cs2pr
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v3
+        uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f
 
       - name: Run composer dependency analyzer
         run: vendor/bin/composer-dependency-analyser --config=composer-dependency-analyser.php

--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -13,6 +13,8 @@ on:
       - 'rector.php'
       - 'yii'
 
+permissions:
+  contents: read
 jobs:
   cs-fix:
     runs-on: ubuntu-latest
@@ -20,17 +22,19 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
 
       - name: Install PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
         with:
           php-version: 8.4
           tools: composer:v2
           coverage: none
 
       - name: Install Composer dependencies
-        uses: "ramsey/composer-install@v4"
+        uses: ramsey/composer-install@26d8a556604053a9612623447203a691f406fbe6
 
       - name: Run PHP CS Fixer
         run: ./vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php
@@ -38,8 +42,13 @@ jobs:
       - name: Run Rector
         run: ./vendor/bin/rector --output-format=github
 
+      - name: Configure Git credentials
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: git config --global credential.helper '!f() { echo username=x-access-token; echo password=$GH_TOKEN; }; f'
+
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9
         with:
           commit_message: "Apply PHP CS Fixer and Rector changes (CI)"
           file_pattern: '*.php'

--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -13,28 +13,33 @@ on:
       - 'rector.php'
       - 'yii'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 jobs:
   cs-fix:
+    name: cs-fix
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write # Required to push PHP CS Fixer and Rector changes to pull requests.
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
       - name: Install PHP
-        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45 # v2 zizmor: ignore[stale-action-refs]
         with:
           php-version: 8.4
           tools: composer:v2
           coverage: none
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@26d8a556604053a9612623447203a691f406fbe6
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
 
       - name: Run PHP CS Fixer
         run: ./vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php
@@ -42,14 +47,19 @@ jobs:
       - name: Run Rector
         run: ./vendor/bin/rector --output-format=github
 
-      - name: Configure Git credentials
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: git config --global credential.helper '!f() { echo username=x-access-token; echo password=$GH_TOKEN; }; f'
-
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9
-        with:
-          commit_message: "Apply PHP CS Fixer and Rector changes (CI)"
-          file_pattern: '*.php'
-          disable_globbing: true
+        env:
+          BRANCH_NAME: ${{ github.head_ref }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git add -- '*.php'
+
+          if git diff --cached --quiet; then
+            exit 0
+          fi
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git commit -m 'Apply PHP CS Fixer and Rector changes (CI)'
+          git push origin "HEAD:$BRANCH_NAME"

--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -32,7 +32,7 @@ jobs:
           persist-credentials: false
 
       - name: Install PHP
-        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45 # v2 zizmor: ignore[stale-action-refs]
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: 8.4
           tools: composer:v2

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -20,6 +20,8 @@ on:
 
 name: static analysis
 
+permissions:
+  contents: read
 jobs:
   psalm:
     name: PHP ${{ matrix.php }}-${{ matrix.os }}
@@ -37,17 +39,19 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Install PHP with extensions
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
         with:
           coverage: none
           php-version: ${{ matrix.php }}
           tools: composer:v2, cs2pr
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v3
+        uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f
 
       - name: Static analysis
         run: vendor/bin/psalm --shepherd --stats --output-format=checkstyle --no-cache --php-version=${{ matrix.php }} | cs2pr --graceful-warnings --colorize

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -20,6 +20,10 @@ on:
 
 name: static analysis
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 jobs:
@@ -39,19 +43,21 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
       - name: Install PHP with extensions
-        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45 # v2 zizmor: ignore[stale-action-refs]
         with:
           coverage: none
           php-version: ${{ matrix.php }}
           tools: composer:v2, cs2pr
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f
+        uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f # 3.2.1
 
       - name: Static analysis
-        run: vendor/bin/psalm --shepherd --stats --output-format=checkstyle --no-cache --php-version=${{ matrix.php }} | cs2pr --graceful-warnings --colorize
+        env:
+          PHP_VERSION: ${{ matrix.php }}
+        run: vendor/bin/psalm --shepherd --stats --output-format=checkstyle --no-cache --php-version="$PHP_VERSION" | cs2pr --graceful-warnings --colorize

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -48,7 +48,7 @@ jobs:
           persist-credentials: false
 
       - name: Install PHP with extensions
-        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45 # v2 zizmor: ignore[stale-action-refs]
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           coverage: none
           php-version: ${{ matrix.php }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -14,8 +14,8 @@ on:
       - '.github/**.yaml'
 
 permissions:
-  actions: read
-  contents: read
+  actions: read # Required by zizmor when reading workflow metadata through the API.
+  contents: read # Required to read workflow files.
 
 jobs:
   zizmor:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,37 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+    push:
+        branches:
+            - main
+        paths:
+            - '.github/**.yml'
+            - '.github/**.yaml'
+    pull_request:
+        paths:
+            - '.github/**.yml'
+            - '.github/**.yaml'
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+permissions:
+    contents: read
+
+jobs:
+    zizmor:
+        name: Run zizmor 🌈
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
+
+            - name: Run zizmor 🌈
+              uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+              with:
+                  advanced-security: false
+                  annotations: true
+                  persona: 'pedantic'

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,5 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        "yiisoft/*": any

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,5 +1,0 @@
-rules:
-  unpinned-uses:
-    config:
-      policies:
-        "yiisoft/*": any


### PR DESCRIPTION
## Summary
- Pin GitHub Actions and reusable Yii workflow references
- Restrict workflow token permissions where applicable
- Disable checkout credential persistence where it is not needed
- Replace floating service image refs where zizmor flagged them

## Validation
- zizmor --no-progress --no-exit-codes .github/workflows
- git diff --check